### PR TITLE
Add new config options

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -75,6 +75,7 @@ func appFiles(path string) ([]string, error) {
 		switch {
 		case
 			regexp.MustCompile(`^.+\.droplet$`).MatchString(filename),
+			regexp.MustCompile(`^.+\.slug`).MatchString(filename),
 			regexp.MustCompile(`^\..+\.cache$`).MatchString(filename):
 			return nil
 		}

--- a/engine/config.go
+++ b/engine/config.go
@@ -26,6 +26,7 @@ type ContainerConfig struct {
 	Entrypoint []string
 	Cmd        []string
 	SkipProxy  bool
+	Port	   string
 
 	// External
 	Binds        []string

--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -45,10 +45,20 @@ func (e *engine) NewContainer(config *eng.ContainerConfig) (eng.Container, error
 		Entrypoint: strslice.StrSlice(config.Entrypoint),
 		Cmd:        strslice.StrSlice(config.Cmd),
 	}
+
+	var port nat.Port
+	if config.Port == "" {
+		port = "8080/tcp"
+	} else {
+		port, err = nat.NewPort("tcp", config.Port);
+		if err != nil {
+			return nil, err
+		}
+	}
 	hostConfig := &cont.HostConfig{
 		Binds: config.Binds,
 		PortBindings: nat.PortMap{
-			"8080/tcp": {{
+			port: {{
 				HostIP:   config.HostIP,
 				HostPort: config.HostPort,
 			}},

--- a/engine/docker/container.go
+++ b/engine/docker/container.go
@@ -36,15 +36,6 @@ func (e *engine) NewContainer(config *eng.ContainerConfig) (eng.Container, error
 	if err != nil {
 		return nil, err
 	}
-	contConfig := &cont.Config{
-		Hostname:   config.Hostname,
-		User:       config.User,
-		Image:      config.Image,
-		WorkingDir: config.WorkingDir,
-		Env:        append(e.proxyEnv(config), config.Env...),
-		Entrypoint: strslice.StrSlice(config.Entrypoint),
-		Cmd:        strslice.StrSlice(config.Cmd),
-	}
 
 	var port nat.Port
 	if config.Port == "" {
@@ -54,6 +45,19 @@ func (e *engine) NewContainer(config *eng.ContainerConfig) (eng.Container, error
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	contConfig := &cont.Config{
+		Hostname:     config.Hostname,
+		User:         config.User,
+		Image:        config.Image,
+		WorkingDir:   config.WorkingDir,
+		Env:          append(e.proxyEnv(config), config.Env...),
+		Entrypoint:   strslice.StrSlice(config.Entrypoint),
+		Cmd:          strslice.StrSlice(config.Cmd),
+		ExposedPorts: nat.PortSet{
+			port: struct{}{},
+		},
 	}
 	hostConfig := &cont.HostConfig{
 		Binds: config.Binds,

--- a/forge.go
+++ b/forge.go
@@ -25,6 +25,7 @@ type AppConfig struct {
 
 type NetworkConfig struct {
 	ContainerID string
+	Port        string
 	HostIP      string
 	HostPort    string
 }

--- a/runner.go
+++ b/runner.go
@@ -141,6 +141,7 @@ func (r *Runner) buildConfig(app *AppConfig, net *NetworkConfig, binds []string,
 		Image:      stack,
 		WorkingDir: workDir,
 		Entrypoint: []string{"/bin/bash", "-c", runScript, app.Command},
+		Port:       net.Port,
 
 		Binds:        binds,
 		NetContainer: net.ContainerID,

--- a/stager.go
+++ b/stager.go
@@ -26,6 +26,7 @@ type StageConfig struct {
 	ForceDetect   bool
 	Color         Colorizer
 	AppConfig     *AppConfig
+	OutputFile    string
 }
 
 type ReadResetWriter interface {
@@ -90,7 +91,12 @@ func (s *Stager) Stage(config *StageConfig) (droplet engine.Stream, err error) {
 		return engine.Stream{}, err
 	}
 
-	return contr.StreamFileFrom("/out/droplet.tgz")
+	outputFile := config.OutputFile
+	if outputFile == "" && len(outputFile) == 0 {
+		outputFile = "droplet.tgz"
+	}
+
+	return contr.StreamFileFrom(fmt.Sprintf("/out/%s", outputFile))
 }
 
 func (s *Stager) buildConfig(app *AppConfig, stack string, forceDetect bool) (*engine.ContainerConfig, error) {

--- a/stager.go
+++ b/stager.go
@@ -27,6 +27,7 @@ type StageConfig struct {
 	Color         Colorizer
 	AppConfig     *AppConfig
 	OutputFile    string
+	SkipStackPull bool
 }
 
 type ReadResetWriter interface {
@@ -43,8 +44,10 @@ func NewStager(engine Engine) *Stager {
 }
 
 func (s *Stager) Stage(config *StageConfig) (droplet engine.Stream, err error) {
-	if err := s.pull(config.Stack); err != nil {
-		return engine.Stream{}, err
+	if config.SkipStackPull == false {
+		if err := s.pull(config.Stack); err != nil {
+			return engine.Stream{}, err
+		}
 	}
 
 	containerConfig, err := s.buildConfig(config.AppConfig, config.Stack, config.ForceDetect)


### PR DESCRIPTION
This PR will allow forge to support multiple output filenames and extensions, such as "slug". The default remains "droplet". In future work, we may:

* Allow the tar exclusions to be configuration (such that other files and directories can be excluded)
* Allow the full path to the output file to be configurable (the `/out` directory is currently a convention used in packs, so this isn't absolutely necessary).

### Update

I've added a few new commits to the PR. They do the following:

* Add a `RootDir` option to the config, which defaults to `/home/vcap`.
* Add a `SkipStackPull` option, which helps with testing locally built packs images